### PR TITLE
BUGFIX: SETI-529 use vanilla rspec_junit_formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ gem "docker-api"
 gem "net-ssh", '~> 2.0'
 gem "colorize"
 gem "parseconfig"
-gem "rspec_junit_formatter", github: 'gooddata/rspec_junit_formatter',
-                             branch: 'yut-qa-5784'
+gem "rspec_junit_formatter"
 gem 'rubocop', '~> 0.37'
 gem 'rubocop-junit-formatter', github: 'gooddata/rubocop-junit-formatter'
 


### PR DESCRIPTION
based on agreement with Michal Vanco: the trouble from the fork
outweighed the benefits of the added feature.  patch replicated
here in full:

commit 04dbb0b4c056fbbf740056a784486efdabaf7ef9
Author: Yury Tsarev <yury.tsarev@gooddata.com>
Date:   Tue Mar 1 22:32:24 2016 +0100

    Enable custom classname prefix injection

diff --git a/lib/rspec_junit_formatter/rspec2.rb b/lib/rspec_junit_formatter/rspec2.rb
index b1c441b..0204839 100644
--- a/lib/rspec_junit_formatter/rspec2.rb
+++ b/lib/rspec_junit_formatter/rspec2.rb
@@ -33,7 +33,8 @@ private

   def classname_for(example)
     fp = example_group_file_path_for(example)
-    fp.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")
+    fp = fp.sub(%r{\.[^/.]+\Z}, "").gsub("/", ".").gsub(/\A\.+|\.+\Z/, "")
+    ENV['TEST_CLASSNAME_PREFIX'] ? "#{ENV['TEST_CLASSNAME_PREFIX']}.#{fp}" : fp
   end

   def duration_for(example)
diff --git a/lib/rspec_junit_formatter/rspec3.rb b/lib/rspec_junit_formatter/rspec3.rb
index b90c7ce..8ca1b96 100644
--- a/lib/rspec_junit_formatter/rspec3.rb
+++ b/lib/rspec_junit_formatter/rspec3.rb
@@ -49,7 +49,8 @@ private

   def classname_for(notification)
     fp = example_group_file_path_for(notification)
-    fp.sub(%r{\.[^/]*\Z}, "").gsub("/", ".").gsub(%r{\A\.+|\.+\Z}, "")
+    fp = fp.sub(%r{\.[^/]*\Z}, "").gsub("/", ".").gsub(%r{\A\.+|\.+\Z}, "")
+    ENV['TEST_CLASSNAME_PREFIX'] ? "#{ENV['TEST_CLASSNAME_PREFIX']}.#{fp}" : fp
   end

   def duration_for(notification)
diff --git a/spec/rspec_junit_formatter_spec.rb b/spec/rspec_junit_formatter_spec.rb
index cc5f4e6..cbbc041 100644
--- a/spec/rspec_junit_formatter_spec.rb
+++ b/spec/rspec_junit_formatter_spec.rb
@@ -19,6 +19,7 @@ describe RspecJunitFormatter do
   before(:all) do
     Dir.chdir EXAMPLE_DIR do
       ENV['TEST_ENV_NUMBER'] = '2'
+      ENV['TEST_CLASSNAME_PREFIX'] = 'prefix'
       system "bundle", "exec", "rspec"
     end
   end
@@ -46,6 +47,12 @@ describe RspecJunitFormatter do
     end
   end

+  it "uses customized classname prefix" do
+    testcases.each do |testcase|
+      expect(testcase["classname"]).to include("prefix")
+    end
+  end
+
   it "has a successful test case" do
     expect(successful_testcases.size).to be 1