### PR TITLE
BUGFIX: SETI-528 peg rspec_junit_formatter to ~> 0.3.0.pre5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "docker-api"
 gem "net-ssh", '~> 2.0'
 gem "colorize"
 gem "parseconfig"
-gem "rspec_junit_formatter"
+gem "rspec_junit_formatter", '~> 0.3.0.pre5'
 gem 'rubocop', '~> 0.37'
 gem 'rubocop-junit-formatter', github: 'gooddata/rubocop-junit-formatter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: git://github.com/gooddata/rspec_junit_formatter.git
-  revision: fb5d3a80a549d4e837992efef90046649b625702
-  branch: master
-  specs:
-    rspec_junit_formatter (0.3.0.pre5)
-      builder (< 4)
-      rspec-core (>= 2, < 4, != 2.12.0)
-
-GIT
   remote: git://github.com/gooddata/rubocop-junit-formatter.git
   revision: a4c2442413cb8c38763ad0df72158a8f2a38ff65
   specs:
@@ -81,6 +72,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    rspec_junit_formatter (0.3.0.pre5)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.37.2)
       parser (>= 2.3.0.4, < 3.0)
       powerpack (~> 0.1)
@@ -122,7 +115,7 @@ DEPENDENCIES
   pry
   rake
   rest-client
-  rspec_junit_formatter!
+  rspec_junit_formatter (~> 0.3.0.pre5)
   rubocop (~> 0.37)
   rubocop-junit-formatter!
   serverspec (~> 2.20)

--- a/serverspec-core.spec
+++ b/serverspec-core.spec
@@ -3,7 +3,7 @@
 Name:             serverspec-core
 Summary:          GoodData ServerSpec integration
 Version:          1.9.13
-Release:          3%{?dist}.gdc1
+Release:          4%{?dist}.gdc1
 
 Vendor:           GoodData
 Group:            GoodData/Tools
@@ -75,6 +75,9 @@ GoodData ServerSpec integration - core package
 %exclude %{install_dir}/spec/types/.gitignore
 
 %changelog
+* Wed Jun 14 2017 Roman Neuhauser <roman.neuhauser@gooddata.com> - 1.9.13-4%{?dist}.gdc1
+- getting the previous revision to actually work
+
 * Wed Jun 14 2017 Roman Neuhauser <roman.neuhauser@gooddata.com> - 1.9.13-3%{?dist}.gdc1
 - update rspec_junit_formatter to 0.3.0.pre5
 


### PR DESCRIPTION
otherwise rubygems.org returns 0.2.3.  plus fix Gemfile.lock.