### PR TITLE
BUGFIX: SETI-537 - Revert to a working version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gem "docker-api"
 gem "net-ssh", '~> 2.0'
 gem "colorize"
 gem "parseconfig"
-gem "rspec_junit_formatter"
+gem "rspec_junit_formatter", github: 'gooddata/rspec_junit_formatter',
+                             branch: 'yut-qa-5784'
 gem 'rubocop', '~> 0.37'
 gem 'rubocop-junit-formatter', github: 'gooddata/rubocop-junit-formatter'
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "docker-api"
 gem "net-ssh", '~> 2.0'
 gem "colorize"
 gem "parseconfig"
-gem "rspec_junit_formatter", '~> 0.3.0.pre5'
+gem "rspec_junit_formatter"
 gem 'rubocop', '~> 0.37'
 gem 'rubocop-junit-formatter', github: 'gooddata/rubocop-junit-formatter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: git://github.com/gooddata/rspec_junit_formatter.git
+  revision: fb5d3a80a549d4e837992efef90046649b625702
+  branch: master
+  specs:
+    rspec_junit_formatter (0.3.0.pre5)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
+
+GIT
   remote: git://github.com/gooddata/rubocop-junit-formatter.git
   revision: a4c2442413cb8c38763ad0df72158a8f2a38ff65
   specs:
@@ -72,8 +81,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rspec_junit_formatter (0.3.0.pre5)
-      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.37.2)
       parser (>= 2.3.0.4, < 3.0)
       powerpack (~> 0.1)
@@ -115,7 +122,7 @@ DEPENDENCIES
   pry
   rake
   rest-client
-  rspec_junit_formatter (~> 0.3.0.pre5)
+  rspec_junit_formatter!
   rubocop (~> 0.37)
   rubocop-junit-formatter!
   serverspec (~> 2.20)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/gooddata/rspec_junit_formatter.git
-  revision: fb5d3a80a549d4e837992efef90046649b625702
-  branch: master
+  revision: 04dbb0b4c056fbbf740056a784486efdabaf7ef9
+  branch: yut-qa-5784
   specs:
-    rspec_junit_formatter (0.3.0.pre5)
+    rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
 

--- a/serverspec-core.spec
+++ b/serverspec-core.spec
@@ -3,7 +3,7 @@
 Name:             serverspec-core
 Summary:          GoodData ServerSpec integration
 Version:          1.9.13
-Release:          2%{?dist}.gdc1
+Release:          5%{?dist}.gdc1
 
 Vendor:           GoodData
 Group:            GoodData/Tools
@@ -75,6 +75,16 @@ GoodData ServerSpec integration - core package
 %exclude %{install_dir}/spec/types/.gitignore
 
 %changelog
+* Thu Jun 15 2017 Andrey Arapov <andrey.arapov@gooddata.com> - 1.9.13-5%{?dist}.gdc1
+- SETI-537: revert two previous changes as they required ruby >2 which we do
+  not have in EL6.
+
+* Wed Jun 14 2017 Roman Neuhauser <roman.neuhauser@gooddata.com> - 1.9.13-4%{?dist}.gdc1
+- getting the previous revision to actually work
+
+* Wed Jun 14 2017 Roman Neuhauser <roman.neuhauser@gooddata.com> - 1.9.13-3%{?dist}.gdc1
+- update rspec_junit_formatter to 0.3.0.pre5
+
 * Tue May 23 2017 Martin Surovcak <martin.surovcak@gooddata.com> - 1.9.13-2%{?dist}.gdc1
 - update specinfra as previous build was buggy
 

--- a/serverspec-core.spec
+++ b/serverspec-core.spec
@@ -3,7 +3,7 @@
 Name:             serverspec-core
 Summary:          GoodData ServerSpec integration
 Version:          1.9.13
-Release:          3%{?dist}.gdc1
+Release:          2%{?dist}.gdc1
 
 Vendor:           GoodData
 Group:            GoodData/Tools
@@ -75,9 +75,6 @@ GoodData ServerSpec integration - core package
 %exclude %{install_dir}/spec/types/.gitignore
 
 %changelog
-* Wed Jun 14 2017 Roman Neuhauser <roman.neuhauser@gooddata.com> - 1.9.13-3%{?dist}.gdc1
-- update rspec_junit_formatter to 0.3.0.pre5
-
 * Tue May 23 2017 Martin Surovcak <martin.surovcak@gooddata.com> - 1.9.13-2%{?dist}.gdc1
 - update specinfra as previous build was buggy
 

--- a/serverspec-core.spec
+++ b/serverspec-core.spec
@@ -3,7 +3,7 @@
 Name:             serverspec-core
 Summary:          GoodData ServerSpec integration
 Version:          1.9.13
-Release:          4%{?dist}.gdc1
+Release:          3%{?dist}.gdc1
 
 Vendor:           GoodData
 Group:            GoodData/Tools
@@ -75,9 +75,6 @@ GoodData ServerSpec integration - core package
 %exclude %{install_dir}/spec/types/.gitignore
 
 %changelog
-* Wed Jun 14 2017 Roman Neuhauser <roman.neuhauser@gooddata.com> - 1.9.13-4%{?dist}.gdc1
-- getting the previous revision to actually work
-
 * Wed Jun 14 2017 Roman Neuhauser <roman.neuhauser@gooddata.com> - 1.9.13-3%{?dist}.gdc1
 - update rspec_junit_formatter to 0.3.0.pre5
 


### PR DESCRIPTION
While working on SETI-537 we have attempted to build a latest rspec_junit_formatter, unfortunately our EL6 has ruby193 and the latest rspec_junit_formatter needs ruby v2.0.0 at least.

https://koji.na.intgdc.com/koji/taskinfo?taskID=86174

```
koji server# find /var/lib/mock/tools-testing-6-ruby193-16284-17692 -type f -name "bundle.log"

Installing rspec_junit_formatter 0.3.0.pre5

Gem::InstallError: rspec_junit_formatter requires Ruby version >= 2.0.0.
```

Because in EL6 we have just ruby193.

```
0.2.3 https://rubygems.org/gems/rspec_junit_formatter
REQUIRED RUBYGEMS VERSION:>= 1.3.6

0.3.0.pre5 https://rubygems.org/gems/rspec_junit_formatter/versions/0.3.0.pre5
REQUIRED RUBYGEMS VERSION:>= 2.0.0
```

``` 2.0 is EOL and nokogiri doesn't support it ```
https://github.com/sj26/rspec_junit_formatter/commit/d881ff19d3ac95d95e472d074263becc7ad10891
