### PR TITLE
SETI-1475: Update rubocop dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "colorize"
 gem "parseconfig"
 gem "rspec_junit_formatter", github: 'gooddata/rspec_junit_formatter',
                              branch: 'yut-qa-5784'
-gem 'rubocop', '~> 0.37'
+gem 'rubocop', '~> 0.49.0'
 gem 'rubocop-junit-formatter', github: 'gooddata/rubocop-junit-formatter'
 
 group :cista do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    ast (2.2.0)
+    ast (2.4.0)
     builder (3.2.2)
     coderay (1.1.0)
     colorize (0.7.5)
@@ -51,15 +51,17 @@ GEM
     net-telnet (0.1.1)
     netrc (0.10.3)
     oauth (0.4.7)
+    parallel (1.12.1)
     parseconfig (1.0.6)
-    parser (2.3.0.6)
-      ast (~> 2.2)
-    powerpack (0.1.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rainbow (2.1.0)
+    rainbow (2.2.2)
+      rake
     rake (10.4.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -81,13 +83,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubocop (0.37.2)
-      parser (>= 2.3.0.4, < 3.0)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 0.3)
-    ruby-progressbar (1.7.5)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     serverspec (2.39.1)
       multi_json
       rspec (~> 3.0)
@@ -106,7 +109,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    unicode-display_width (0.3.1)
+    unicode-display_width (1.4.0)
 
 PLATFORMS
   ruby
@@ -123,10 +126,10 @@ DEPENDENCIES
   rake
   rest-client
   rspec_junit_formatter!
-  rubocop (~> 0.37)
+  rubocop (~> 0.49.0)
   rubocop-junit-formatter!
   serverspec (~> 2.20)
   specinfra (~> 2.68)
 
 BUNDLED WITH
-   1.11.2
+   1.15.2

--- a/serverspec-core.spec
+++ b/serverspec-core.spec
@@ -3,7 +3,7 @@
 Name:             serverspec-core
 Summary:          GoodData ServerSpec integration
 Version:          1.9.13
-Release:          6%{?dist}.gdc1
+Release:          7%{?dist}.gdc1
 
 Vendor:           GoodData
 Group:            GoodData/Tools
@@ -75,6 +75,9 @@ GoodData ServerSpec integration - core package
 %exclude %{install_dir}/spec/types/.gitignore
 
 %changelog
+* Fri Jul 27 2018 Michal Vanco <michal.vanco@gooddata.com> - 1.9.13-7%{?dist}.gdc1
+- SETI-1475: update rubocop version due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418
+
 * Thu Jun 15 2017 Andrey Arapov <andrey.arapov@gooddata.com> - 1.9.13-6%{?dist}.gdc1
 - SETI-537: use patches from rspec_junit_formatter 0.3.0.pre5
 


### PR DESCRIPTION
There is a security vulnerability:
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418