### PR TITLE
TRIVIAL: tune for building on el9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,11 @@ gem "docker-api"
 gem "net-ssh", '~> 2.0'
 gem "colorize"
 gem "parseconfig"
-gem "rspec_junit_formatter", github: 'gooddata/rspec_junit_formatter',
+gem "rspec_junit_formatter", git: 'https://github.com/gooddata/rspec_junit_formatter',
                              branch: 'yut-qa-5784'
 gem 'rubocop', '~> 0.49.0'
-gem 'rubocop-junit-formatter', github: 'gooddata/rubocop-junit-formatter'
+gem 'rubocop-junit-formatter', git: 'https://github.com/gooddata/rubocop-junit-formatter'
+gem 'rexml'
 
 group :cista do
   gem 'jira-ruby', require: 'jira'

--- a/specs/serverspec-core.spec
+++ b/specs/serverspec-core.spec
@@ -8,7 +8,7 @@
 Name:             serverspec-core
 Summary:          GoodData ServerSpec integration
 Version:          2.0.1
-Release:          1%{?dist}.gdc1
+Release:          2%{?dist}.gdc1
 
 Group:            GoodData/Tools
 


### PR DESCRIPTION
adding rexml gem (not bundled anymore by default in ruby3)
change github url to clone directly from https